### PR TITLE
close connection when commands fail

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -69,6 +69,10 @@ Connection.prototype = {
       _this._log('closing connection');
       _this._connection.end();
       return [stdout, stderr];
+    }).catch(function(err) {
+      _this._log('closing connection');
+      _this._connection.end();
+      return [false, err];
     });
   },
 


### PR DESCRIPTION
Actually, if the commands return a code > 0, the connection is not closed. I propose this workaround to close connection and return an error inside resolve.